### PR TITLE
Added some scripts and pipeline WIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.iml
 .idea/
+.clusterid
+.networkid
+.civo-kubeconfig

--- a/civo/create.sh
+++ b/civo/create.sh
@@ -1,0 +1,58 @@
+#! /bin/bash
+
+if [ "$CIVO_API_KEY" == "" ]; then
+    printf "CIVO_API_KEY is not set. Visit the Security tab in your Civo\n"
+    printf "account settings page to get your key, then set it with the command"
+    printf "\n\n\texport CIVO_API_KEY=<key value>\n\n"
+    printf "then run this script again\n"
+    exit 1
+fi
+
+if ! type jq > /dev/null; then
+    echo "\n\nVisit https://stedolan.github.io/jq/ to install jq to parse"
+    echo "Civo API responses\n\n"
+    exit 1
+fi
+
+echo "CIVO_API_KEY is set"
+
+USERNAME=`whoami`
+CIVO_API_URL="https://api.civo.com/v2"
+KUBECONFIG=null
+NETWORKD_ID=null
+CLUSTER_ID=null
+
+echo "Creating cluster $USERNAME-jfrog-linkerd"
+AUTH_HEADER="Authorization: bearer $CIVO_API_KEY"
+
+# curl -H "$AUTH_HEADER" $CIVO_API_URL/kubernetes/clusters
+
+NETWORK_ID=$(curl -s -H "$AUTH_HEADER" \
+    $CIVO_API_URL/networks | jq '.[].id' -r)
+
+CLUSTER_ID=$(curl -s -H "$AUTH_HEADER" -X POST $CIVO_API_URL/kubernetes/clusters \
+    -d "name=$USERNAME-jfrog-linkerd&target_nodes_size=g4s.kube.medium&num_target_nodes=2&network_id=$NETWORK_ID" |
+    jq '.id' -r)
+
+printf "\n\n\tCluster ID is $CLUSTER_ID\n\n"
+
+while [ "$KUBECONFIG" == "null" ];do
+    echo "Sleeping for 30 seconds before getting the kubeconfig file"
+    sleep 30
+    KUBECONFIG=$(curl -s -H "$AUTH_HEADER" \
+        $CIVO_API_URL/kubernetes/clusters/$CLUSTER_ID | jq .kubeconfig -r)
+    #echo "new kubeconfig $KUBECONFIG"
+done
+
+echo $CLUSTER_ID > .clusterid
+echo $NETWORK_ID > .networkid
+echo "$KUBECONFIG" > .civo-kubeconfig
+
+kubectl get po -n kube-system
+kubectl get node
+
+printf "\n\nYour cluster has been created with id $CLUSTER_ID which you can"
+printf "find in the .clusterid file"
+printf "Run the following command to set the KUBECONFIG environment variable"
+printf "to use the .civo-kubeconfig file"
+printf "\n\n\texport KUBECONFIG=`pwd`/.civo-kubeconfig\n\n"

--- a/linkerd/Dockerfile
+++ b/linkerd/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine/k8s:1.21.5
+
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+
+RUN apk update && apk add \
+    openssl \
+    step-cli 
+
+RUN step version
+
+RUN curl -sL https://run.linkerd.io/install | sh
+
+ENV PATH=$PATH:/root/.linkerd2/bin
+
+EXPOSE 50750
+
+
+

--- a/pipelines.yaml
+++ b/pipelines.yaml
@@ -13,6 +13,8 @@ pipelines:
     steps:
     - name: linkerdCheck
       type: Bash
+      integrations:
+      - name: civo_k8s
       execution:
         onExecute:
           - linkerd version

--- a/pipelines.yaml
+++ b/pipelines.yaml
@@ -1,3 +1,16 @@
+resources:
+  - name: workshop_repo
+    type: GitRepo
+    configuration:
+      gitProvider: GitHub
+      path: cpretzer/workshop-jfrog-linkerd
+      branches:
+        include: main
+      buildOn:
+        commit: true
+        pullRequestCreate: true
+        releaseRequestCreate: true
+
 pipelines:
   - name: linkerdDeploy
     configuration:
@@ -10,6 +23,8 @@ pipelines:
             autoPull: true
             registry: artifactory
             sourceRepository: linkerd-docker-local
+      inputResources:
+      - name: workshop_repo
     steps:
     - name: linkerdCheck
       type: Bash

--- a/pipelines.yaml
+++ b/pipelines.yaml
@@ -1,0 +1,18 @@
+pipelines:
+  - name: linkerd-deploy
+    configuration:
+      runtime:
+        type: image
+        image:
+          custom:
+            name: alpine/k8s
+            tag: v0.1.0
+            autoPull: true
+            registry: artifactory
+            sourceRepository: linkerd-docker-local
+    steps:
+    - name: linkerd-check
+      type: Bash
+      execution:
+        onExecute:
+          - linkerd version

--- a/pipelines.yaml
+++ b/pipelines.yaml
@@ -11,7 +11,7 @@ pipelines:
             registry: artifactory
             sourceRepository: linkerd-docker-local
     steps:
-    - name: linkerd-check
+    - name: linkerdCheck
       type: Bash
       execution:
         onExecute:

--- a/pipelines.yaml
+++ b/pipelines.yaml
@@ -1,5 +1,5 @@
 pipelines:
-  - name: linkerd-deploy
+  - name: linkerdDeploy
     configuration:
       runtime:
         type: image

--- a/pipelines.yaml
+++ b/pipelines.yaml
@@ -5,7 +5,7 @@ pipelines:
         type: image
         image:
           custom:
-            name: alpine/k8s
+            name: cpretzer.jfrog.io/linkerd-docker-local/alpine/k8s
             tag: v0.1.0
             autoPull: true
             registry: artifactory


### PR DESCRIPTION
The `civo/create.sh` script is a very basic attempt at enabling folks to create a civo cluster via a script, rather than the UI. 

They will still have to create a Civo account and log in to get their API key. Instructions for that are included in the script and will be documented later.  

`linkerd/Dockerfile` is a simple Dockerfile that uses `alpine/k8s` as the base (which includes helm, kubectl, and several other k8s tools). The image is hosted at https://cpretzer.jfrog.io/linkerd-docker-local/alpine/k8s:v.01.0, but I don't know how to verify whether this is a public or private image. 

`pipelines.yaml` is the WIP and uses the custom image created by the Dockerfile to attempt to deploy Linkerd to the cluster.  At the moment, I need to figure out how to mount the `.civo-kubeconfig` file that is created by the `civo/create.sh` script into the Linkerd image in the pipeline. I haven't found anything helpful for mounting a file as a volume on the custom runner image. 